### PR TITLE
[Fix] Invalid link to pracovni prostor ontology

### DIFF
--- a/src/main/resources/mapping
+++ b/src/main/resources/mapping
@@ -3,5 +3,5 @@ http://onto.fel.cvut.cz/ontologies/application/termit/glosář > ../../../ontolo
 http://onto.fel.cvut.cz/ontologies/application/termit/model > ../../../ontology/termit-model.ttl
 http://rdfs.org/sioc/ns# > ../../../ontology/sioc-ns.rdf
 http://www.w3.org/ns/activitystreams# > https://raw.githubusercontent.com/w3c/activitystreams/master/vocabulary/activitystreams2.owl
-https://slovník.gov.cz/datový/pracovní-prostor/glosář > https://raw.githubusercontent.com/opendata-mvcr/ssp/master/content/d-sgov/d-sgov-pracovn%C3%AD-prostor-0.0.1/d-sgov-pracovn%C3%AD-prostor-0.0.1-glos%C3%A1%C5%99.ttl
-https://slovník.gov.cz/datový/pracovní-prostor/model > https://raw.githubusercontent.com/opendata-mvcr/ssp/master/content/d-sgov/d-sgov-pracovn%C3%AD-prostor-0.0.1/d-sgov-pracovn%C3%AD-prostor-0.0.1-model.ttl
+https://slovník.gov.cz/datový/pracovní-prostor/glosář > https://raw.githubusercontent.com/opendata-mvcr/ssp/master/content/vocabularies/d-sgov-pracovní-prostor-0.0.1/d-sgov-pracovní-prostor-0.0.1-glosář.ttl
+https://slovník.gov.cz/datový/pracovní-prostor/model > https://raw.githubusercontent.com/opendata-mvcr/ssp/master/content/vocabularies/d-sgov-pracovní-prostor-0.0.1/d-sgov-pracovní-prostor-0.0.1-model.ttl


### PR DESCRIPTION
Should fix build of docker image. I assume it fails due to:
```
[WARNING] Unable to import ontology [https://slovník.gov.cz/datový/pracovní-prostor/model](https://xn--slovnk-7va.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/model).
[WARNING] Unable to import ontology [https://slovník.gov.cz/datový/pracovní-prostor/glosář](https://xn--slovnk-7va.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/glos%C3%A1%C5%99).
```