### PR TITLE
Fix term deletion from all vocabulary drafts and canonical version

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -760,6 +760,17 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
     }
 
     @Override
+    public Optional<Term> getReference(URI id) {
+        Objects.requireNonNull(id);
+        try {
+            Descriptor descriptor = descriptorFactory.termDescriptor(resolveTermVocabulary(id));
+            return Optional.ofNullable(em.getReference(type, id, descriptor));
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    @Override
     public List<Snapshot> findSnapshots(Term asset) {
         return new AssetSnapshotLoader<Term>(em, typeUri, URI.create(
                 cz.cvut.kbss.termit.util.Vocabulary.s_c_verze_pojmu)).findSnapshots(asset);


### PR DESCRIPTION
Fixes deletion of a term from all vocabulary drafts and canonical version instead of just deleting from the selected draft.
Also now allows to create a term that is present in different draft version.
Term count correction to only count in the selected draft.

Closes #100 
Closes #101 